### PR TITLE
Fix : 사격시 카메라 떨림, 먹통 현상 수정

### DIFF
--- a/OverwatchDefenseMobile/Assets/Prefabs/Peacekeeper.prefab
+++ b/OverwatchDefenseMobile/Assets/Prefabs/Peacekeeper.prefab
@@ -31,7 +31,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -151,3 +151,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _rigidbody: {fileID: 1764340833413234399}
   _collider: {fileID: 2453049988409711030}
+  target: {fileID: 0}

--- a/OverwatchDefenseMobile/Assets/Scenes/InGameScene.unity
+++ b/OverwatchDefenseMobile/Assets/Scenes/InGameScene.unity
@@ -1802,8 +1802,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.263, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 108.98464}
+  m_SizeDelta: {x: 0, y: -217.9693}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2007042435
 MonoBehaviour:

--- a/OverwatchDefenseMobile/Assets/Scripts/Controller/CameraRotate.cs
+++ b/OverwatchDefenseMobile/Assets/Scripts/Controller/CameraRotate.cs
@@ -8,7 +8,7 @@ public class CameraRotate : MonoBehaviour
     [SerializeField] private Camera _camera;
     [SerializeField] private RectTransform _panelRectTransform;
     [SerializeField] private Transform _playerTransform;
-    [SerializeField] private float _rotateSensitivity;
+    [SerializeField] private float _rotateSensitivity;    
 
     private Dictionary<int, Vector2> _lastTouchPos = new Dictionary<int, Vector2>();
     private float _rotateHorizontal;
@@ -20,10 +20,8 @@ public class CameraRotate : MonoBehaviour
         _rotateVertical = transform.localEulerAngles.x;
     }
 
-
     private void Update()
-    {
-        
+    {        
         foreach (TouchControl touch in Touchscreen.current.touches)
         {
             
@@ -56,5 +54,5 @@ public class CameraRotate : MonoBehaviour
             _playerTransform.eulerAngles = new Vector3(0f, _rotateHorizontal, 0f);
             _camera.transform.localEulerAngles = new Vector3(_rotateVertical, 0f, 0f);
         }
-    }
+    }    
 }

--- a/OverwatchDefenseMobile/Assets/Scripts/Test/CassidyTest.cs
+++ b/OverwatchDefenseMobile/Assets/Scripts/Test/CassidyTest.cs
@@ -120,7 +120,7 @@ public class CassidyTest: Character
 
 
     public override void NormalAttack()
-    {
+    {        
         StartCoroutine(C_NormalAtk());
     }
 
@@ -136,7 +136,7 @@ public class CassidyTest: Character
         {
             if (hit.collider.CompareTag("Zomnic"))
             {
-                projectileManager.FireProjectile(Camera.main.transform.position, Camera.main.transform.forward, peacekeeperBullet);
+                projectileManager.FireProjectile(Camera.main.transform.position + Camera.main.transform.forward, Camera.main.transform.forward, peacekeeperBullet);
                 peacekeeper.isSkillPossible = false;
                 peacekeeperCurrentBulletCount--;
 
@@ -176,7 +176,6 @@ public class CassidyTest: Character
         yield return new WaitForSeconds(flashbang.skillCoolTime);
         flashbang.isSkillPossible = true;
     }
-
 
     public void Skill_CombatRoll()
     {
@@ -232,6 +231,6 @@ public class CassidyTest: Character
         cam.localRotation = startRot;
 
         yield return new WaitForSeconds(combatRoll.skillCoolTime);
-        combatRoll.isSkillPossible = true;
+        combatRoll.isSkillPossible = true;        
     }
 }


### PR DESCRIPTION
총알 prefab의 크기 줄이고 생성위치를 카메라보다 앞으로 조정해 물리 충돌로 인한 밀림 방지, 카메라 회전 입력을 받는 Right Panel의 범위를 버튼과 겹치지 않도록 수정